### PR TITLE
bugfix/Fix app bounce

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -31,6 +31,7 @@ html,
 body {
   height: 100%;
   overflow: hidden;
+  touch-action: none;
 }
 .cdv-default-layout {
   overflow: hidden;


### PR DESCRIPTION
Disabling the touch actions on the body seems to fix the general app bouncing. 

All the other events seems to still be workin in the emulator. Could be a nice idea to test on real device